### PR TITLE
chore(ci): add informational Codecov status checks

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -17,8 +17,12 @@ coverage:
   round: down
   status:
     changes: off
-    project: off
-    patch: off
+    project:
+      default:
+        informational: true
+    patch:
+      default:
+        informational: true
 parsers:
   gcov:
     branch_detection:


### PR DESCRIPTION
# Pull Request title
No bug issue

Hi, Tom from Codecov here. I noticed that you were using Codecov but weren't actually getting any notifications on pull requests. I figured it would be useful to get some idea if code being changed is being tested, but also not blocking CI/merging. Let me know if this makes sense or if we can do something that would be helpful.

